### PR TITLE
Add `.success` property to check if last call was resolved

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var unparse = require('escodegen').generate;
 
-module.exports = function (ast, vars) {
+module.exports = function staticEval (ast, vars) {
     if (!vars) vars = {};
     var FAIL = {};
     
@@ -172,5 +172,6 @@ module.exports = function (ast, vars) {
         else return FAIL;
     })(ast);
     
+    staticEval.success = result !== FAIL
     return result === FAIL ? undefined : result;
 };

--- a/readme.markdown
+++ b/readme.markdown
@@ -68,7 +68,8 @@ tree object `ast` with an optional collection of variables `vars` to use in the
 static expression resolution.
 
 If the expression contained in `ast` can't be statically resolved, `evaluate()`
-returns undefined.
+returns undefined. You can also use the `evaluate.success` property to check if
+the most recent call succeeded.
 
 # install
 

--- a/test/eval.js
+++ b/test/eval.js
@@ -3,7 +3,7 @@ var evaluate = require('../');
 var parse = require('esprima').parse;
 
 test('resolved', function (t) {
-    t.plan(1);
+    t.plan(2);
     
     var src = '[1,2,3+4*10+(n||6),foo(3+5),obj[""+"x"].y]';
     var ast = parse(src).body[0].expression;
@@ -12,11 +12,12 @@ test('resolved', function (t) {
         foo: function (x) { return x * 100 },
         obj: { x: { y: 555 } }
     });
+    t.ok(evaluate.success);
     t.deepEqual(res, [ 1, 2, 49, 800, 555 ]);
 });
 
 test('unresolved', function (t) {
-    t.plan(1);
+    t.plan(2);
     
     var src = '[1,2,3+4*10*z+n,foo(3+5),obj[""+"x"].y]';
     var ast = parse(src).body[0].expression;
@@ -25,6 +26,7 @@ test('unresolved', function (t) {
         foo: function (x) { return x * 100 },
         obj: { x: { y: 555 } }
     });
+    t.notOk(evaluate.success);
     t.equal(res, undefined);
 });
 
@@ -53,30 +55,33 @@ test('array methods with vars', function(t) {
 });
 
 test('evaluate this', function(t) {
-    t.plan(1);
+    t.plan(2);
 
     var src = 'this.x + this.y.z';
     var ast = parse(src).body[0].expression;
     var res = evaluate(ast, {
         'this': { x: 1, y: { z: 100 } }
     });
+    t.ok(evaluate.success);
     t.equal(res, 101);
 });
 
 test('FunctionExpression unresolved', function(t) {
-    t.plan(1);
+    t.plan(2);
 
     var src = '(function(){console.log("Not Good")})';
     var ast = parse(src).body[0].expression;
     var res = evaluate(ast, {});
+    t.notOk(evaluate.success);
     t.equal(res, undefined);
 });
 
 test('MemberExpressions from Functions unresolved', function(t) {
-    t.plan(1);
+    t.plan(2);
 
     var src = '(function () {}).constructor';
     var ast = parse(src).body[0].expression;
     var res = evaluate(ast, {});
+    t.notOk(evaluate.success);
     t.equal(res, undefined);
 });

--- a/test/prop.js
+++ b/test/prop.js
@@ -3,7 +3,7 @@ var evaluate = require('../');
 var parse = require('esprima').parse;
 
 test('function property', function (t) {
-    t.plan(1);
+    t.plan(2);
     
     var src = '[1,2,3+4*10+n,beep.boop(3+5),obj[""+"x"].y]';
     var ast = parse(src).body[0].expression;
@@ -12,5 +12,6 @@ test('function property', function (t) {
         beep: { boop: function (x) { return x * 100 } },
         obj: { x: { y: 555 } }
     });
+    t.ok(evaluate.success);
     t.deepEqual(res, [ 1, 2, 49, 800, 555 ]);
 });

--- a/test/template-strings.js
+++ b/test/template-strings.js
@@ -3,18 +3,19 @@ var evaluate = require('../');
 var parse = require('esprima').parse;
 
 test('untagged template strings', function (t) {
-    t.plan(1);
+    t.plan(2);
     
     var src = '`${1},${2 + n},${`4,5`}`';
     var ast = parse(src).body[0].expression;
     var res = evaluate(ast, {
         n: 6
     });
+    t.ok(evaluate.success);
     t.deepEqual(res, '1,8,4,5');
 });
 
 test('tagged template strings', function (t) {
-    t.plan(3);
+    t.plan(4);
 
     var src = 'template`${1},${2 + n},${`4,5`}`';
     var ast = parse(src).body[0].expression;
@@ -29,5 +30,6 @@ test('tagged template strings', function (t) {
         },
         n: 6
     });
+    t.ok(evaluate.success);
     t.deepEqual(res, 'foo');
 })


### PR DESCRIPTION
Sometimes nodes are supposed to resolve to `undefined`, so we can't rely on that alone to check if an evaluation succeeded. This PR adds a property that you can check after calling `evaluate`:

```js
var res = evaluate({ type: 'Identifier', name: 'undefined' })
if (evaluate.success) console.log(res)
else process.exit(1)
```